### PR TITLE
fix: feedback banner mobile overlap and stats timezone inconsistency

### DIFF
--- a/backend/v2/controllers/accesses.js
+++ b/backend/v2/controllers/accesses.js
@@ -99,7 +99,17 @@ const parseBrowser = (userAgent) => {
 const getLinkStats = async (req, res) => {
   const user = req.user;
   const guest = req.guest;
-  const { period } = req.query; // '7d' | '30d' | 'all'
+  const { period, tz } = req.query; // '7d' | '30d' | 'all'
+
+  // Helper: format a Date as YYYY-MM-DD in the given timezone (falls back to UTC)
+  const toLocalDateStr = (date) => {
+    try {
+      if (!tz) throw new Error();
+      return new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit' }).format(date);
+    } catch {
+      return date.toISOString().split('T')[0];
+    }
+  };
 
   try {
     const link = await prisma.link.findUnique({ where: { shortUrl: req.params.shortUrl } });
@@ -136,7 +146,7 @@ const getLinkStats = async (req, res) => {
     for (let i = days - 1; i >= 0; i--) {
       const d = new Date(now);
       d.setDate(d.getDate() - i);
-      dateMap[d.toISOString().split('T')[0]] = 0;
+      dateMap[toLocalDateStr(d)] = 0;
     }
 
     const countries = {};
@@ -144,7 +154,7 @@ const getLinkStats = async (req, res) => {
     let vpnCount = 0, botCount = 0, qrCount = 0, directCount = 0;
 
     for (const a of accesses) {
-      const day = new Date(a.createdAt).toISOString().split('T')[0];
+      const day = toLocalDateStr(new Date(a.createdAt));
       if (dateMap[day] !== undefined) dateMap[day]++;
       countries[a.country] = (countries[a.country] || 0) + 1;
       const b = parseBrowser(a.userAgent);

--- a/frontend/app/components/FeedbackBanner/FeedbackBanner.tsx
+++ b/frontend/app/components/FeedbackBanner/FeedbackBanner.tsx
@@ -54,7 +54,7 @@ export default function FeedbackBanner() {
           animate={{ y: 0 }}
           exit={{ y: "120%" }}
           transition={{ type: "spring", stiffness: 320, damping: 28, delay: 1.2 }}
-          className="fixed bottom-4 left-4 right-4 md:left-auto md:right-4 z-40 md:w-md bg-warning rounded-2xl border-2 border-dark shadow-[4px_4px_0_var(--color-dark)] p-5"
+          className="fixed bottom-28 md:bottom-4 left-4 right-4 md:left-auto md:right-4 z-40 md:w-md bg-warning rounded-2xl border-2 border-dark shadow-[4px_4px_0_var(--color-dark)] p-5"
         >
           {/* Close */}
           <button

--- a/frontend/app/services/api/statsService.ts
+++ b/frontend/app/services/api/statsService.ts
@@ -19,8 +19,9 @@ export interface LinkStats {
 
 export const statsService = {
   getLinkStats: async (shortUrl: string, period: StatsPeriod): Promise<LinkStats> => {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const res = await fetch(
-      `${API_CONFIG.BASE_URL}/accesses/link/${shortUrl}/stats?period=${period}`,
+      `${API_CONFIG.BASE_URL}/accesses/link/${shortUrl}/stats?period=${period}&tz=${encodeURIComponent(tz)}`,
       { credentials: 'include' }
     );
     const data = await res.json();


### PR DESCRIPTION
- Raise FeedbackBanner bottom offset on mobile (bottom-28) to clear the fixed bottom nav
- Pass user timezone (Intl.DateTimeFormat) to stats API so chart groups accesses by local date instead of UTC, fixing day mismatch between history and overview chart