### PR TITLE
feat: redesign use case cards with persona stories and Tabler icons

### DIFF
--- a/frontend/app/components/Landing/UseCaseCard.tsx
+++ b/frontend/app/components/Landing/UseCaseCard.tsx
@@ -1,36 +1,56 @@
+import { ElementType } from "react";
+
 /**
- * Use case card for the use cases section.
+ * Use case card for the use cases section — shows a persona who benefits from Linkkk.
  */
 export default function UseCaseCard({
   color,
-  title,
+  icon: Icon,
+  role,
+  name,
   description,
-  footer,
+  tagline,
+  light = false,
   className = "",
 }: {
   color: string;
-  title: string;
+  icon: ElementType;
+  role: string;
+  name: string;
   description: string;
-  footer: string;
+  tagline: string;
+  light?: boolean;
   className?: string;
 }) {
+  const text = light ? "text-light" : "text-dark";
+  const textMuted = light ? "text-light/50" : "text-dark/50";
+  const textBody = light ? "text-light/75" : "text-dark/75";
+  const textTagline = light ? "text-light/60" : "text-dark/60";
+  const border = light ? "border-light/15" : "border-dark/15";
+  const iconColor = light ? "text-light/10" : "text-dark/10";
+
   return (
     <div
-      className={`${color} ${className} aspect-square w-44 md:w-48 rounded-2xl p-4 md:p-5 flex flex-col justify-start gap-2`}
+      className={`${color} ${className} relative w-44 md:w-52 h-56 md:h-60 rounded-2xl p-4 md:p-5 flex flex-col justify-between shrink-0 overflow-hidden`}
     >
+      {/* Decorative icon — large, bottom-right, semi-transparent */}
+      <Icon
+        size={100}
+        strokeWidth={3}
+        className={`absolute -bottom-3 -right-3 -rotate-45 pointer-events-none select-none ${iconColor}`}
+      />
+
+      {/* Top: identity */}
       <div>
-        <h3 className="font-black italic text-base md:text-lg text-dark leading-tight mb-2 md:mb-3">
-          {title}
-        </h3>
-        <p className="text-[11px] md:text-xs text-dark/80 leading-snug">
-          {description}
-        </p>
+        <p className={`text-[10px] md:text-[11px] font-black uppercase tracking-wider ${textMuted} mb-0.5`}>{role}</p>
+        <h3 className={`font-black italic text-base md:text-lg ${text} leading-tight`}>{name}</h3>
       </div>
-      {footer && (
-        <p className="text-[11px] md:text-xs text-dark/80 leading-snug">
-          {footer}
-        </p>
-      )}
+
+      {/* Middle: description */}
+      <p className={`text-[11px] md:text-xs ${textBody} leading-snug`}>{description}</p>
+
+      {/* Bottom: tagline */}
+      <p className={`text-[11px] md:text-xs font-bold ${textTagline} leading-snug border-t ${border} pt-2`}>{tagline}</p>
     </div>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -37,6 +37,11 @@ import {
   TbInfoCircle,
   TbChevronDown,
   TbHeartFilled,
+  TbMicrophone2,
+  TbChartBar,
+  TbShoppingBag,
+  TbBriefcase,
+  TbRocket,
 } from "react-icons/tb";
 
 gsap.registerPlugin(ScrollTrigger);
@@ -743,73 +748,90 @@ export default function Landing() {
           <div className="flex gap-4 w-max">
             <UseCaseCard
               color="bg-primary"
-              title="Ofertas geo-segmentadas"
-              description="Cada país tiene su oferta. Cada clic debería ir a la correcta."
-              footer="Sin redirecciones manuales. Sin comisiones perdidas."
+              icon={TbMicrophone2}
+              role="Creadora de contenido"
+              name="Ana"
+              description="Un solo link en su bio que manda a YouTube, Spotify o Amazon según lo que busca su seguidor."
+              tagline="Menos fricción. Más conversiones."
             />
             <UseCaseCard
               color="bg-warning"
-              title="App y Web en un solo link"
-              description="Móvil va a la App Store. Escritorio va a la web."
-              footer="Un link. Dos experiencias. Cero lógica en tu código."
+              icon={TbChartBar}
+              role="Growth marketer"
+              name="Carlos"
+              description="Lanza campañas en 5 canales. Sabe exactamente cuál convierte y cuáles son bots."
+              tagline="Datos reales. Decisiones reales."
             />
             <UseCaseCard
               color="bg-info"
-              title="Campañas con fecha de caducidad"
-              description="Antes de la deadline: página de oferta. Después: página normal."
-              footer="Automatizado. Sin tocar nada manualmente."
+              icon={TbShoppingBag}
+              role="Dueña de ecommerce"
+              name="Sofía"
+              description="Móvil va a su app. Escritorio va a la web. Sin una línea de código extra."
+              tagline="Un link. Dos experiencias."
             />
             <UseCaseCard
               color="bg-danger"
-              title="Webhooks cuando algo sucede"
-              description="Un bot accede. Un usuario de un país específico hace clic. Un límite se alcanza."
-              footer=""
+              icon={TbBriefcase}
+              role="Freelancer"
+              name="David"
+              description="Manda su portfolio a un cliente. Sabe cuándo lo abren, desde dónde, y cuántas veces."
+              tagline="Nunca más el «¿lo viste ya?»"
             />
             <UseCaseCard
               color="bg-secondary"
-              title="Escudo anti-bots"
-              description="Bloquea bots y tráfico VPN antes de que devoren tu presupuesto."
-              footer="Solo clics reales. Solo datos reales."
+              icon={TbRocket}
+              role="Indie hacker"
+              name="Marta"
+              description="Pone una fecha de expiración a su oferta de lanzamiento. Después el link redirige al precio normal."
+              tagline="Urgencia real. Sin mentiras."
+              light
             />
           </div>
         </div>
 
         {/* Desktop */}
-        <div className="usecases-cards hidden md:flex flex-wrap gap-4 justify-center items-start">
+        <div className="usecases-cards hidden md:flex flex-wrap gap-4 justify-center items-stretch">
           <UseCaseCard
-
             color="bg-primary"
-            title="Ofertas geo-segmentadas"
-            description="Cada país tiene su oferta. Cada clic debería ir a la correcta."
-            footer="Sin redirecciones manuales. Sin comisiones perdidas."
+            icon={TbMicrophone2}
+            role="Creadora de contenido"
+            name="Ana"
+            description="Un solo link en su bio que manda a YouTube, Spotify o Amazon según lo que busca su seguidor."
+            tagline="Menos fricción. Más conversiones."
           />
           <UseCaseCard
-
             color="bg-warning"
-            title="App y Web en un solo link"
-            description="Móvil va a la App Store. Escritorio va a la web."
-            footer="Un link. Dos experiencias. Cero lógica en tu código."
+            icon={TbChartBar}
+            role="Growth marketer"
+            name="Carlos"
+            description="Lanza campañas en 5 canales. Sabe exactamente cuál convierte y cuáles son bots."
+            tagline="Datos reales. Decisiones reales."
           />
           <UseCaseCard
-
             color="bg-info"
-            title="Campañas con fecha de caducidad"
-            description="Antes de la deadline: página de oferta. Después: página normal."
-            footer="Automatizado. Sin tocar nada manualmente."
+            icon={TbShoppingBag}
+            role="Dueña de ecommerce"
+            name="Sofía"
+            description="Móvil va a su app. Escritorio va a la web. Sin una línea de código extra."
+            tagline="Un link. Dos experiencias."
           />
           <UseCaseCard
-
             color="bg-danger"
-            title="Webhooks cuando algo sucede"
-            description="Un bot accede. Un usuario de un país específico hace clic. Un límite se alcanza."
-            footer=""
+            icon={TbBriefcase}
+            role="Freelancer"
+            name="David"
+            description="Manda su portfolio a un cliente. Sabe cuándo lo abren, desde dónde, y cuántas veces."
+            tagline="Nunca más el «¿lo viste ya?»"
           />
           <UseCaseCard
-
             color="bg-secondary"
-            title="Escudo anti-bots"
-            description="Bloquea bots y tráfico VPN antes de que devoren tu presupuesto."
-            footer="Solo clics reales. Solo datos reales."
+            icon={TbRocket}
+            role="Indie hacker"
+            name="Marta"
+            description="Pone una fecha de expiración a su oferta de lanzamiento. Después el link redirige al precio normal."
+            tagline="Urgencia real. Sin mentiras."
+            light
           />
         </div>
       </section>


### PR DESCRIPTION
- Replace feature-focused cards with real user personas (Ana, Carlos, Sofía, David, Marta)
- Add large decorative Tabler icon positioned bottom-right with low opacity
- Fix uniform card height (fixed h-56/h-60 instead of aspect-square)
- Add light prop for dark background cards (secondary uses white text)