### PR TITLE
feat: add custom domains support for PRO users

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,55 @@
+# =============================================================================
+# Caddyfile — linkkk.dev
+# =============================================================================
+# On-demand TLS lets Caddy auto-provision certs for custom user domains.
+# Before issuing a cert, Caddy asks /internal/check-domain to verify the
+# domain is registered and active in the database.
+# =============================================================================
+
+{
+    on_demand_tls {
+        ask http://localhost:4000/internal/check-domain
+        interval 2m
+        burst 5
+    }
+}
+
+# ── Main app ─────────────────────────────────────────────────────────────────
+linkkk.dev, www.linkkk.dev {
+    # Frontend (Next.js)
+    reverse_proxy * localhost:3000
+
+    # Backend API
+    reverse_proxy /api/* localhost:4000
+
+    encode gzip
+}
+
+# ── Custom user domains (on-demand TLS) ──────────────────────────────────────
+# Accepts any domain that Caddy doesn't already handle above.
+# Cert is requested on first visit and cached automatically.
+:443 {
+    tls {
+        on_demand
+    }
+
+    encode gzip
+
+    # Rewrite bare slugs to /r/:slug so the backend redirect handler picks them up.
+    # The only exceptions are Linkkk's own UI pages that the backend redirects to
+    # (password gate, blocked, 404, disabled) — those go to Next.js.
+    @frontend path /password* /blocked* /404* /disabled* /error*
+    reverse_proxy @frontend localhost:3000
+
+    @slug {
+        not path /password* /blocked* /404* /disabled* /error* /r/*
+    }
+    rewrite @slug /r{path}
+
+    reverse_proxy /r/* localhost:4000
+}
+
+# Redirect plain HTTP to HTTPS for custom domains
+:80 {
+    redir https://{host}{uri} permanent
+}

--- a/backend/__tests__/domain.test.js
+++ b/backend/__tests__/domain.test.js
@@ -1,0 +1,248 @@
+require('./setup');
+const request = require('supertest');
+const { app, createTestUser, getCsrfToken, prisma } = require('./helpers');
+
+async function createTestProUser(suffix = '') {
+  const { user, token } = await createTestUser(`test_pro${suffix}`, `pro${suffix}@example.com`);
+  const upgraded = await prisma.user.update({
+    where: { id: user.id },
+    data: { role: 'PRO' },
+  });
+  return { user: upgraded, token };
+}
+
+async function authHeaders(token) {
+  const { csrfToken, cookies } = await getCsrfToken();
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-CSRF-Token': csrfToken,
+      Cookie: cookies?.join('; ') || '',
+      'Content-Type': 'application/json',
+    },
+  };
+}
+
+afterEach(async () => {
+  await prisma.customDomain.deleteMany({});
+});
+
+describe('Custom Domains', () => {
+  describe('GET /domain', () => {
+    it('returns empty list for a new PRO user', async () => {
+      const { token } = await createTestProUser('_list');
+      const { headers } = await authHeaders(token);
+
+      const res = await request(app).get('/domain').set(headers).expect(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual([]);
+    });
+
+    it('rejects unauthenticated requests', async () => {
+      await request(app).get('/domain').expect(401);
+    });
+  });
+
+  describe('POST /domain', () => {
+    it('PRO user can add a valid subdomain', async () => {
+      const { token } = await createTestProUser('_add');
+      const { headers } = await authHeaders(token);
+
+      const res = await request(app)
+        .post('/domain')
+        .set(headers)
+        .send({ domain: 'go.testdomain.com' })
+        .expect(201);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.domain).toBe('go.testdomain.com');
+      expect(res.body.data.status).toBe('PENDING');
+    });
+
+    it('rejects root domains (no subdomain)', async () => {
+      const { token } = await createTestProUser('_root');
+      const { headers } = await authHeaders(token);
+
+      const res = await request(app)
+        .post('/domain')
+        .set(headers)
+        .send({ domain: 'testdomain.com' })
+        .expect(400);
+
+      expect(res.body.code).toBe('DOMAIN_INVALID');
+    });
+
+    it('rejects linkkk.dev subdomains', async () => {
+      const { token } = await createTestProUser('_linkkk');
+      const { headers } = await authHeaders(token);
+
+      const res = await request(app)
+        .post('/domain')
+        .set(headers)
+        .send({ domain: 'go.linkkk.dev' })
+        .expect(400);
+
+      expect(res.body.code).toBe('DOMAIN_INVALID');
+    });
+
+    it('rejects invalid domain format', async () => {
+      const { token } = await createTestProUser('_invalid');
+      const { headers } = await authHeaders(token);
+
+      const res = await request(app)
+        .post('/domain')
+        .set(headers)
+        .send({ domain: 'not a domain!' })
+        .expect(400);
+
+      expect(res.body.code).toBe('DOMAIN_INVALID');
+    });
+
+    it('rejects a domain already registered by another user', async () => {
+      const { token: tokenA } = await createTestProUser('_dupA');
+      const { token: tokenB } = await createTestProUser('_dupB');
+      const { headers: headersA } = await authHeaders(tokenA);
+      const { headers: headersB } = await authHeaders(tokenB);
+
+      await request(app)
+        .post('/domain')
+        .set(headersA)
+        .send({ domain: 'go.duplicate.com' })
+        .expect(201);
+
+      const res = await request(app)
+        .post('/domain')
+        .set(headersB)
+        .send({ domain: 'go.duplicate.com' })
+        .expect(400);
+
+      expect(res.body.code).toBe('DOMAIN_ALREADY_EXISTS');
+    });
+
+    it('STANDARD user cannot add a domain', async () => {
+      const { token } = await createTestUser('test_standard_dom', 'standard_dom@example.com');
+      const { headers } = await authHeaders(token);
+
+      const res = await request(app)
+        .post('/domain')
+        .set(headers)
+        .send({ domain: 'go.testdomain.com' })
+        .expect(400);
+
+      expect(res.body.code).toBe('DOMAIN_LIMIT_EXCEEDED');
+    });
+
+    it('PRO user cannot exceed the domain limit', async () => {
+      const { token } = await createTestProUser('_limit');
+      const { headers } = await authHeaders(token);
+
+      await request(app)
+        .post('/domain')
+        .set(headers)
+        .send({ domain: 'go.first.com' })
+        .expect(201);
+
+      const res = await request(app)
+        .post('/domain')
+        .set(headers)
+        .send({ domain: 'go.second.com' })
+        .expect(400);
+
+      expect(res.body.code).toBe('DOMAIN_LIMIT_EXCEEDED');
+    });
+  });
+
+  describe('DELETE /domain/:domainId', () => {
+    it('PRO user can delete their own domain', async () => {
+      const { token } = await createTestProUser('_del');
+      const { headers } = await authHeaders(token);
+
+      const created = await request(app)
+        .post('/domain')
+        .set(headers)
+        .send({ domain: 'go.todelete.com' })
+        .expect(201);
+
+      const id = created.body.data.id;
+
+      const res = await request(app)
+        .delete(`/domain/${id}`)
+        .set(headers)
+        .expect(200);
+
+      expect(res.body.data.deleted).toBe(true);
+    });
+
+    it('cannot delete another user\'s domain', async () => {
+      const { token: tokenA } = await createTestProUser('_delA');
+      const { token: tokenB } = await createTestProUser('_delB');
+      const { headers: headersA } = await authHeaders(tokenA);
+      const { headers: headersB } = await authHeaders(tokenB);
+
+      const created = await request(app)
+        .post('/domain')
+        .set(headersA)
+        .send({ domain: 'go.usera.com' })
+        .expect(201);
+
+      const id = created.body.data.id;
+
+      const res = await request(app)
+        .delete(`/domain/${id}`)
+        .set(headersB)
+        .expect(403);
+
+      expect(res.body.code).toBe('DOMAIN_ACCESS_DENIED');
+    });
+  });
+
+  describe('GET /internal/check-domain', () => {
+    it('returns 404 for an unknown domain', async () => {
+      await request(app)
+        .get('/internal/check-domain?domain=go.unknown.com')
+        .expect(404);
+    });
+
+    it('returns 404 for a PENDING domain (not yet verified)', async () => {
+      const { token } = await createTestProUser('_chk');
+      const { headers } = await authHeaders(token);
+
+      await request(app)
+        .post('/domain')
+        .set(headers)
+        .send({ domain: 'go.pending.com' })
+        .expect(201);
+
+      await request(app)
+        .get('/internal/check-domain?domain=go.pending.com')
+        .expect(404);
+    });
+
+    it('returns 200 for an ACTIVE domain', async () => {
+      const { token, user } = await createTestProUser('_chkactive');
+      const { headers } = await authHeaders(token);
+
+      const created = await request(app)
+        .post('/domain')
+        .set(headers)
+        .send({ domain: 'go.active.com' })
+        .expect(201);
+
+      // Force status to ACTIVE directly in DB (skips real DNS check)
+      await prisma.customDomain.update({
+        where: { id: created.body.data.id },
+        data: { status: 'ACTIVE', verifiedAt: new Date() },
+      });
+
+      await request(app)
+        .get('/internal/check-domain?domain=go.active.com')
+        .expect(200);
+    });
+
+    it('returns 400 when domain query param is missing', async () => {
+      await request(app)
+        .get('/internal/check-domain')
+        .expect(400);
+    });
+  });
+});

--- a/backend/v2.js
+++ b/backend/v2.js
@@ -23,9 +23,11 @@ const userRouter = require("./v2/routers/user");
 const subscriptionRouter = require("./v2/routers/subscription");
 const tagRouter = require("./v2/routers/tag");
 const groupRouter = require("./v2/routers/group");
+const domainRouter = require("./v2/routers/domain");
 
 // Controllers
 const { redirectLink } = require("./v2/controllers/link");
+const { checkDomainForCaddy } = require("./v2/controllers/domain");
 
 const app = express();
 const PORT = config.server.port;
@@ -221,6 +223,17 @@ app.use("/subscription", (req, res, next) => {
   }
   return csrfProtection(req, res, next);
 }, subscriptionRouter);
+
+app.use("/domain", csrfProtection, domainRouter);
+
+// Internal endpoint for Caddy on-demand TLS — only reachable from localhost
+app.get("/internal/check-domain", (req, res, next) => {
+  const ip = req.ip || "";
+  if (ip !== "127.0.0.1" && ip !== "::1" && ip !== "::ffff:127.0.0.1") {
+    return res.sendStatus(403);
+  }
+  return next();
+}, checkDomainForCaddy);
 
 // Public redirect endpoint (LAST - catches everything else)
 app.get("/r/:shortUrl", redirectLink);

--- a/backend/v2/constants/errorCodes.js
+++ b/backend/v2/constants/errorCodes.js
@@ -301,6 +301,52 @@ const ERRORS = {
   },
 
   // ============================================================================
+  // CUSTOM DOMAIN ERRORS
+  // ============================================================================
+  DOMAIN_NOT_FOUND: {
+    code: "DOMAIN_NOT_FOUND",
+    message: "Domain not found",
+    userMessage: "The domain you're looking for doesn't exist",
+    statusCode: 404,
+    retryable: false,
+  },
+  DOMAIN_ACCESS_DENIED: {
+    code: "DOMAIN_ACCESS_DENIED",
+    message: "Access denied to domain",
+    userMessage: "You don't have permission to access this domain",
+    statusCode: 403,
+    retryable: false,
+  },
+  DOMAIN_ALREADY_EXISTS: {
+    code: "DOMAIN_ALREADY_EXISTS",
+    message: "Domain already registered",
+    userMessage: "This domain is already registered in Linkkk",
+    statusCode: 400,
+    retryable: false,
+  },
+  DOMAIN_INVALID: {
+    code: "DOMAIN_INVALID",
+    message: "Invalid domain format",
+    userMessage: "The domain format is invalid",
+    statusCode: 400,
+    retryable: false,
+  },
+  DOMAIN_DNS_FAILED: {
+    code: "DOMAIN_DNS_FAILED",
+    message: "DNS verification failed",
+    userMessage: "DNS verification failed. Make sure your CNAME record is pointing to linkkk.dev and try again",
+    statusCode: 400,
+    retryable: true,
+  },
+  DOMAIN_LIMIT_EXCEEDED: {
+    code: "DOMAIN_LIMIT_EXCEEDED",
+    message: "Domain limit exceeded",
+    userMessage: "You've reached your custom domain limit. Upgrade your plan to add more domains",
+    statusCode: 400,
+    retryable: false,
+  },
+
+  // ============================================================================
   // SYSTEM ERRORS
   // ============================================================================
   INTERNAL_ERROR: {

--- a/backend/v2/controllers/domain.js
+++ b/backend/v2/controllers/domain.js
@@ -1,0 +1,128 @@
+const dns = require("dns").promises;
+const prisma = require("../prisma/client");
+const { successResponse, errorResponse } = require("../utils/response");
+const ERRORS = require("../constants/errorCodes");
+const { getLimitsForUser } = require("../utils/limits");
+
+const DOMAIN_REGEX = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+
+const getDomains = async (req, res) => {
+  const domains = await prisma.customDomain.findMany({
+    where: { userId: req.user.id },
+    orderBy: { createdAt: "desc" },
+  });
+  return successResponse(res, domains);
+};
+
+const addDomain = async (req, res) => {
+  const { domain } = req.body;
+
+  if (!domain || !DOMAIN_REGEX.test(domain)) {
+    return errorResponse(res, ERRORS.DOMAIN_INVALID);
+  }
+
+  const normalized = domain.toLowerCase().trim();
+
+  // Must be a subdomain (at least 3 parts: sub.domain.tld)
+  if (normalized.split(".").length < 3) {
+    return errorResponse(res, ERRORS.DOMAIN_INVALID);
+  }
+
+  // Block adding linkkk.dev subdomains
+  if (normalized === "linkkk.dev" || normalized.endsWith(".linkkk.dev")) {
+    return errorResponse(res, ERRORS.DOMAIN_INVALID);
+  }
+
+  const limits = getLimitsForUser(req.user, null);
+  if (limits.customDomains === 0) {
+    return errorResponse(res, ERRORS.DOMAIN_LIMIT_EXCEEDED);
+  }
+
+  const count = await prisma.customDomain.count({ where: { userId: req.user.id } });
+  if (limits.customDomains !== null && count >= limits.customDomains) {
+    return errorResponse(res, ERRORS.DOMAIN_LIMIT_EXCEEDED);
+  }
+
+  try {
+    const created = await prisma.customDomain.create({
+      data: { userId: req.user.id, domain: normalized },
+    });
+    return successResponse(res, created, 201);
+  } catch (error) {
+    if (error.code === "P2002") {
+      return errorResponse(res, ERRORS.DOMAIN_ALREADY_EXISTS);
+    }
+    return errorResponse(res, ERRORS.INTERNAL_ERROR);
+  }
+};
+
+const verifyDomain = async (req, res) => {
+  const domainId = parseInt(req.params.domainId, 10);
+  if (isNaN(domainId)) return errorResponse(res, ERRORS.DOMAIN_NOT_FOUND);
+
+  const record = await prisma.customDomain.findUnique({ where: { id: domainId } });
+  if (!record) return errorResponse(res, ERRORS.DOMAIN_NOT_FOUND);
+  if (record.userId !== req.user.id) return errorResponse(res, ERRORS.DOMAIN_ACCESS_DENIED);
+
+  await prisma.customDomain.update({
+    where: { id: domainId },
+    data: { status: "VERIFYING", errorMsg: null },
+  });
+
+  // DNS lookup: the domain's CNAME must resolve to linkkk.dev
+  try {
+    const cnames = await dns.resolveCname(record.domain);
+    const pointsToLinkkk = cnames.some(
+      (c) => c === "linkkk.dev" || c.endsWith(".linkkk.dev")
+    );
+
+    if (!pointsToLinkkk) {
+      await prisma.customDomain.update({
+        where: { id: domainId },
+        data: {
+          status: "ERROR",
+          errorMsg: `CNAME resolves to [${cnames.join(", ")}] instead of linkkk.dev`,
+        },
+      });
+      return errorResponse(res, ERRORS.DOMAIN_DNS_FAILED);
+    }
+
+    const updated = await prisma.customDomain.update({
+      where: { id: domainId },
+      data: { status: "ACTIVE", verifiedAt: new Date(), errorMsg: null },
+    });
+    return successResponse(res, updated);
+  } catch {
+    await prisma.customDomain.update({
+      where: { id: domainId },
+      data: { status: "ERROR", errorMsg: "CNAME record not found" },
+    });
+    return errorResponse(res, ERRORS.DOMAIN_DNS_FAILED);
+  }
+};
+
+const deleteDomain = async (req, res) => {
+  const domainId = parseInt(req.params.domainId, 10);
+  if (isNaN(domainId)) return errorResponse(res, ERRORS.DOMAIN_NOT_FOUND);
+
+  const record = await prisma.customDomain.findUnique({ where: { id: domainId } });
+  if (!record) return errorResponse(res, ERRORS.DOMAIN_NOT_FOUND);
+  if (record.userId !== req.user.id) return errorResponse(res, ERRORS.DOMAIN_ACCESS_DENIED);
+
+  await prisma.customDomain.delete({ where: { id: domainId } });
+  return successResponse(res, { deleted: true });
+};
+
+// Internal endpoint consumed by Caddy on-demand TLS — not exposed to users
+const checkDomainForCaddy = async (req, res) => {
+  const domain = req.query.domain;
+  if (!domain) return res.sendStatus(400);
+
+  const record = await prisma.customDomain.findFirst({
+    where: { domain: domain.toLowerCase(), status: "ACTIVE" },
+  });
+
+  return res.sendStatus(record ? 200 : 404);
+};
+
+module.exports = { getDomains, addDomain, verifyDomain, deleteDomain, checkDomainForCaddy };

--- a/backend/v2/controllers/link.js
+++ b/backend/v2/controllers/link.js
@@ -404,9 +404,25 @@ const redirectLink = async (req, res) => {
   const source = req.query.src === "qr" ? "qr" : "direct";
 
   try {
-    // Fetch link with rules
+    // Resolve owner from custom domain if request comes from one
+    let customDomainUserId = null;
+    const host = (req.headers["host"] || "").split(":")[0].toLowerCase();
+    if (host && host !== "linkkk.dev" && !host.endsWith(".linkkk.dev")) {
+      const customDomain = await prisma.customDomain.findFirst({
+        where: { domain: host, status: "ACTIVE" },
+      });
+      if (!customDomain) {
+        return res.redirect(`${config.frontend.url}/404?url=${shortUrl}`);
+      }
+      customDomainUserId = customDomain.userId;
+    }
+
+    // Fetch link with rules — scope to domain owner when using a custom domain
     const link = await prisma.link.findUnique({
-      where: { shortUrl },
+      where: {
+        shortUrl,
+        ...(customDomainUserId !== null ? { userId: customDomainUserId } : {}),
+      },
       include: {
         rules: {
           where: { enabled: true },

--- a/backend/v2/prisma/schema.prisma
+++ b/backend/v2/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   oauthId       String?
   groups        Group[]
   tags          Tag[]
+  customDomains CustomDomain[]
 
   @@unique([oauthProvider, oauthId])
 }
@@ -304,4 +305,26 @@ enum DotsStyle {
 enum CornersStyle {
   square
   rounded
+}
+
+enum CustomDomainStatus {
+  PENDING
+  VERIFYING
+  ACTIVE
+  ERROR
+}
+
+model CustomDomain {
+  id         Int                @id @default(autoincrement())
+  userId     Int
+  user       User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  domain     String             @unique
+  status     CustomDomainStatus @default(PENDING)
+  errorMsg   String?
+  verifiedAt DateTime?
+  createdAt  DateTime           @default(now())
+  updatedAt  DateTime           @updatedAt
+
+  @@index([userId])
+  @@index([domain, status])
 }

--- a/backend/v2/routers/domain.js
+++ b/backend/v2/routers/domain.js
@@ -1,0 +1,11 @@
+const express = require("express");
+const router = express.Router();
+const { auth, authUser } = require("../middlewares/auth");
+const { getDomains, addDomain, verifyDomain, deleteDomain } = require("../controllers/domain");
+
+router.get("/", auth, authUser, getDomains);
+router.post("/", auth, authUser, addDomain);
+router.post("/:domainId/verify", auth, authUser, verifyDomain);
+router.delete("/:domainId", auth, authUser, deleteDomain);
+
+module.exports = router;

--- a/backend/v2/utils/limits.js
+++ b/backend/v2/utils/limits.js
@@ -7,6 +7,7 @@ const planLimits = {
     groups: 0,
     tags: 0,
     tagsPerLink: 0,
+    customDomains: 0,
     linkAnalytics: {
       linkCharts: false,
       linkAccesses: 0,
@@ -21,6 +22,7 @@ const planLimits = {
     groups: 5,
     tags: 20,
     tagsPerLink: 5,
+    customDomains: 0,
     linkAnalytics: {
       linkCharts: true,
       linkAccesses: null,
@@ -35,6 +37,7 @@ const planLimits = {
     groups: null,
     tags: null,
     tagsPerLink: null,
+    customDomains: 1,
     linkAnalytics: {
       linkCharts: true,
       linkAccesses: null,

--- a/frontend/app/components/CustomDomains/CustomDomains.tsx
+++ b/frontend/app/components/CustomDomains/CustomDomains.tsx
@@ -1,0 +1,230 @@
+"use client";
+import { useState, useEffect } from "react";
+import {
+  TbWorld,
+  TbPlus,
+  TbTrash,
+  TbRefresh,
+  TbCheck,
+  TbX,
+  TbCopy,
+  TbLoader2,
+  TbSparkles,
+} from "react-icons/tb";
+import { useTranslations } from "next-intl";
+import Button from "@/app/components/ui/Button/Button";
+import { domainService, type CustomDomain } from "@/app/services/api/domainService";
+import { HttpError } from "@/app/utils/errors";
+import { useToast } from "@/app/hooks/useToast";
+import { useAuth } from "@/app/hooks";
+
+const CNAME_TARGET = "linkkk.dev";
+
+export default function CustomDomains() {
+  const t = useTranslations("CustomDomains");
+  const toast = useToast();
+  const { user } = useAuth();
+  const isPro = user?.role === "PRO";
+
+  const [domains, setDomains] = useState<CustomDomain[]>([]);
+  const [newDomain, setNewDomain] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [adding, setAdding] = useState(false);
+  const [verifying, setVerifying] = useState<number | null>(null);
+  const [deleting, setDeleting] = useState<number | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const STATUS_CONFIG = {
+    PENDING: { label: t("statusPending"), color: "bg-dark/10 text-dark", icon: TbLoader2, spin: false },
+    VERIFYING: { label: t("statusVerifying"), color: "bg-secondary/20 text-secondary", icon: TbLoader2, spin: true },
+    ACTIVE: { label: t("statusActive"), color: "bg-primary/30 text-dark", icon: TbCheck, spin: false },
+    ERROR: { label: t("statusError"), color: "bg-danger/20 text-danger", icon: TbX, spin: false },
+  };
+
+  useEffect(() => {
+    if (!isPro) { setLoading(false); return; }
+    domainService.getAll().then(setDomains).finally(() => setLoading(false));
+  }, [isPro]);
+
+  const handleAdd = async () => {
+    if (!newDomain.trim()) return;
+    setAdding(true);
+    try {
+      const created = await domainService.add(newDomain.trim());
+      setDomains((prev) => [created, ...prev]);
+      setNewDomain("");
+    } catch (error) {
+      toast.error(error instanceof HttpError ? error.message : t("toastAddFailed"));
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleVerify = async (id: number) => {
+    setVerifying(id);
+    try {
+      const updated = await domainService.verify(id);
+      setDomains((prev) => prev.map((d) => (d.id === id ? updated : d)));
+      if (updated.status === "ACTIVE") {
+        toast.success(t("toastVerifySuccess"));
+      } else {
+        toast.error(t("toastVerifyFailed"));
+      }
+    } catch (error) {
+      toast.error(error instanceof HttpError ? error.message : t("toastVerifyFailed"));
+    } finally {
+      setVerifying(null);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    setDeleting(id);
+    try {
+      await domainService.remove(id);
+      setDomains((prev) => prev.filter((d) => d.id !== id));
+    } catch (error) {
+      toast.error(error instanceof HttpError ? error.message : t("toastRemoveFailed"));
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(CNAME_TARGET);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  // PRO gate
+  if (!isPro) {
+    return (
+      <div className="p-6 bg-dark/5 rounded-2xl border-2 border-dashed border-dark/20 flex flex-col items-center text-center gap-3">
+        <TbSparkles size={32} className="text-primary" />
+        <h3 className="text-xl font-bold">{t("title")}</h3>
+        <p className="text-dark/60 text-sm">{t("proOnly")}</p>
+        <p className="text-dark/40 text-sm">{t("upgradePrompt")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Add domain */}
+      <div className="p-4 bg-dark/5 rounded-2xl border-2 border-dashed border-transparent focus-within:border-dark transition-colors">
+        <div className="flex items-center gap-2 mb-3">
+          <TbWorld size={20} />
+          <h3 className="text-xl font-bold">{t("title")}</h3>
+        </div>
+        <p className="text-sm text-dark/60 mb-1">
+          {t("description", {
+            target: (
+              <button
+                key="cname-target"
+                onClick={handleCopy}
+                className="inline-flex items-center gap-1 font-mono font-bold text-primary hover:underline"
+              >
+                {CNAME_TARGET}
+                {copied ? <TbCheck size={14} /> : <TbCopy size={14} />}
+              </button>
+            ),
+          })}
+        </p>
+        <p className="text-xs text-dark/40 mb-4">{t("subdomainNote")}</p>
+
+        {/* DNS instructions box */}
+        <div className="mb-4 p-3 bg-dark/5 rounded-xl border border-dashed border-dark/20 font-mono text-sm grid grid-cols-3 gap-2">
+          <div>
+            <p className="text-dark/40 text-xs mb-1">{t("dnsType")}</p>
+            <p className="font-bold">CNAME</p>
+          </div>
+          <div>
+            <p className="text-dark/40 text-xs mb-1">{t("dnsName")}</p>
+            <p className="font-bold">go</p>
+          </div>
+          <div>
+            <p className="text-dark/40 text-xs mb-1">{t("dnsValue")}</p>
+            <p className="font-bold">{CNAME_TARGET}</p>
+          </div>
+        </div>
+
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={newDomain}
+            onChange={(e) => setNewDomain(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAdd()}
+            placeholder={t("placeholder")}
+            className="flex-1 p-3 bg-dark/5 rounded-xl border-2 border-dashed border-transparent focus:border-dark outline-none transition-colors font-mono text-sm"
+          />
+          <Button
+            variant="solid"
+            size="sm"
+            rounded="xl"
+            onClick={handleAdd}
+            disabled={adding || !newDomain.trim()}
+            className="bg-dark hover:bg-primary hover:text-dark border border-dark"
+          >
+            {adding ? <TbLoader2 className="animate-spin" size={18} /> : <TbPlus size={18} />}
+          </Button>
+        </div>
+      </div>
+
+      {/* Domain list */}
+      {loading ? (
+        <div className="flex items-center justify-center py-8 text-dark/40">
+          <TbLoader2 className="animate-spin mr-2" size={20} />
+          <span>{t("loading")}</span>
+        </div>
+      ) : domains.length === 0 ? (
+        <p className="text-center text-dark/40 py-6 text-sm">{t("empty")}</p>
+      ) : (
+        <div className="space-y-3">
+          {domains.map((domain) => {
+            const cfg = STATUS_CONFIG[domain.status];
+            const StatusIcon = cfg.icon;
+            return (
+              <div
+                key={domain.id}
+                className="flex items-center justify-between gap-3 p-4 bg-dark/5 rounded-2xl"
+              >
+                <div className="min-w-0">
+                  <p className="font-mono font-bold truncate">{domain.domain}</p>
+                  {domain.errorMsg && (
+                    <p className="text-xs text-danger mt-0.5 truncate">{domain.errorMsg}</p>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2 shrink-0">
+                  <span className={`inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-bold ${cfg.color}`}>
+                    <StatusIcon size={12} className={cfg.spin ? "animate-spin" : ""} />
+                    {cfg.label}
+                  </span>
+
+                  {domain.status !== "ACTIVE" && (
+                    <button
+                      onClick={() => handleVerify(domain.id)}
+                      disabled={verifying === domain.id}
+                      title={t("btnVerify")}
+                      className="p-2 rounded-xl bg-dark/5 hover:bg-secondary hover:text-light transition-colors disabled:opacity-50"
+                    >
+                      <TbRefresh size={16} className={verifying === domain.id ? "animate-spin" : ""} />
+                    </button>
+                  )}
+
+                  <button
+                    onClick={() => handleDelete(domain.id)}
+                    disabled={deleting === domain.id}
+                    title={t("btnRemove")}
+                    className="p-2 rounded-xl bg-dark/5 hover:bg-danger hover:text-light transition-colors disabled:opacity-50"
+                  >
+                    <TbTrash size={16} />
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1143,41 +1143,6 @@ export default function Landing() {
         </div>
       </section>
 
-      {/* ==================== SEO CONTENT SECTION ==================== */}
-      <section className="bg-light py-16 px-6 border-t border-dark/10">
-        <div className="max-w-3xl mx-auto">
-          <h2 className="text-2xl font-black italic text-dark mb-4">About Linkkk</h2>
-          <p className="text-dark/70 leading-relaxed mb-6">
-            Linkkk is a free, open-source link management platform built for creators, marketers, and developers
-            who need more than a simple URL shortener. Every short link you create can have conditional redirect
-            rules — route mobile users to your app store listing, block bots from polluting your analytics,
-            require a password before revealing the destination, or schedule a link to expire automatically.
-            The rules engine requires no coding knowledge: pick conditions, choose actions, and save.
-          </p>
-          <p className="text-dark/70 leading-relaxed mb-8">
-            All plans include real-time <Link href="/docs/analytics" className="text-primary font-bold hover:underline">click analytics</Link> with
-            country, device, browser, and referrer breakdowns, plus auto-generated{" "}
-            <Link href="/docs/qr" className="text-primary font-bold hover:underline">QR codes</Link> for every link.
-            Linkkk is self-hostable under an MIT license — read the{" "}
-            <a href="https://github.com/aka-alvaroso/Linkkk" target="_blank" rel="noopener noreferrer" className="text-primary font-bold hover:underline">source code on GitHub</a>.
-            GDPR-compliant by design: IPs are anonymized, passwords are hashed with{" "}
-            <a href="https://en.wikipedia.org/wiki/Bcrypt" target="_blank" rel="noopener noreferrer" className="text-primary font-bold hover:underline">bcrypt</a>,
-            and we never sell your data.
-          </p>
-          <div className="flex flex-wrap gap-4 text-sm">
-            <Link href="/docs/getting-started" className="text-primary font-bold hover:underline">
-              Getting started guide →
-            </Link>
-            <Link href="/docs/rules" className="text-primary font-bold hover:underline">
-              How rules work →
-            </Link>
-            <Link href="/docs/plans" className="text-primary font-bold hover:underline">
-              Compare plans →
-            </Link>
-          </div>
-        </div>
-      </section>
-
       {/* ==================== FOOTER ==================== */}
       <footer className="relative bg-dark py-16 pb-24 md:py-24 px-6 overflow-hidden">
         {/* Decorative watermark */}

--- a/frontend/app/services/api/domainService.ts
+++ b/frontend/app/services/api/domainService.ts
@@ -1,0 +1,79 @@
+import { API_CONFIG, defaultFetchOptions } from "@/app/config/api";
+import { HttpError, NetworkError, TimeoutError } from "@/app/utils/errors";
+import type { ApiResponse } from "@/app/types";
+import { csrfService } from "./csrfService";
+
+export interface CustomDomain {
+  id: number;
+  domain: string;
+  status: "PENDING" | "VERIFYING" | "ACTIVE" | "ERROR";
+  errorMsg: string | null;
+  verifiedAt: string | null;
+  createdAt: string;
+}
+
+class DomainService {
+  private baseUrl = `${API_CONFIG.BASE_URL}/domain`;
+
+  private async handleResponse<T>(response: Response): Promise<T> {
+    let data: ApiResponse<T>;
+    try {
+      data = await response.json();
+    } catch {
+      throw new HttpError(response.status, "INVALID_RESPONSE", "Invalid response from server", false);
+    }
+    if (!response.ok) {
+      throw new HttpError(response.status, data.code || "UNKNOWN_ERROR", data.message || response.statusText, response.status >= 500);
+    }
+    if (!data.success || data.data === undefined) {
+      throw new HttpError(response.status, data.code || "UNKNOWN_ERROR", data.message || "Unknown error occurred", false);
+    }
+    return data.data;
+  }
+
+  private async request<T>(url: string, options: RequestInit): Promise<T> {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), API_CONFIG.TIMEOUT);
+      const method = options.method?.toUpperCase() || "GET";
+      const headers: Record<string, string> = {
+        ...(defaultFetchOptions.headers as Record<string, string>),
+        ...(options.headers as Record<string, string> || {}),
+      };
+      if (method !== "GET") {
+        try {
+          headers["X-CSRF-Token"] = await csrfService.getToken();
+        } catch { /* continue without token */ }
+      }
+      const response = await fetch(url, { ...defaultFetchOptions, ...options, headers, signal: controller.signal });
+      clearTimeout(timeoutId);
+      return this.handleResponse<T>(response);
+    } catch (error) {
+      if (error instanceof HttpError) throw error;
+      if (error instanceof Error && error.name === "AbortError") throw new TimeoutError();
+      if (error instanceof TypeError) throw new NetworkError();
+      throw new NetworkError("An unexpected error occurred");
+    }
+  }
+
+  async getAll(): Promise<CustomDomain[]> {
+    return this.request<CustomDomain[]>(this.baseUrl, { method: "GET" });
+  }
+
+  async add(domain: string): Promise<CustomDomain> {
+    return this.request<CustomDomain>(this.baseUrl, {
+      method: "POST",
+      body: JSON.stringify({ domain }),
+    });
+  }
+
+  async verify(domainId: number): Promise<CustomDomain> {
+    return this.request<CustomDomain>(`${this.baseUrl}/${domainId}/verify`, { method: "POST", body: JSON.stringify({}) });
+  }
+
+  async remove(domainId: number): Promise<void> {
+    await this.request<{ deleted: boolean }>(`${this.baseUrl}/${domainId}`, { method: "DELETE" });
+  }
+}
+
+export const domainService = new DomainService();

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -27,12 +27,14 @@ import CancelSubscriptionModal from "@/app/components/Modal/CancelSubscriptionMo
 import SelectPlanModal from "@/app/components/Modal/SelectPlanModal";
 import { HttpError } from "@/app/utils/errors";
 import LanguageSwitcher from "@/app/components/ui/LanguageSwitcher/LanguageSwitcher";
+import CustomDomains from "@/app/components/CustomDomains/CustomDomains";
+import { TbWorld } from "react-icons/tb";
 
 import { API_CONFIG } from "@/app/config/api";
 
 const API_BASE_URL = API_CONFIG.BASE_URL;
 
-type SettingsTab = "account" | "security" | "danger";
+type SettingsTab = "account" | "security" | "domains" | "danger";
 
 interface SettingsTabConfig {
   id: SettingsTab;
@@ -56,6 +58,7 @@ export default function SettingsPage() {
   const settingsTabs: SettingsTabConfig[] = [
     { id: "account", label: t('tabAccount'), icon: TbUser },
     { id: "security", label: t('tabSecurity'), icon: TbLock },
+    { id: "domains", label: t('tabDomains'), icon: TbWorld },
     { id: "danger", label: t('tabDangerZone'), icon: TbAlertTriangle },
   ];
 
@@ -328,6 +331,8 @@ export default function SettingsPage() {
                   activeColor = "bg-primary text-dark border border-dark shadow-[4px_4px_0_var(--color-dark)]";
                 } else if (tab.id === "security") {
                   activeColor = "bg-secondary text-light border border-dark shadow-[4px_4px_0_var(--color-dark)]";
+                } else if (tab.id === "domains") {
+                  activeColor = "bg-dark text-light border border-dark shadow-[4px_4px_0_var(--color-dark)]";
                 } else if (tab.id === "danger") {
                   activeColor = "bg-danger text-light border border-dark shadow-[4px_4px_0_var(--color-dark)]";
                 }
@@ -366,6 +371,8 @@ export default function SettingsPage() {
                     activeColor = "bg-primary text-dark border border-dark shadow-[4px_4px_0_var(--color-dark)]";
                   } else if (tab.id === "security") {
                     activeColor = "bg-secondary text-light border border-dark shadow-[4px_4px_0_var(--color-dark)]";
+                  } else if (tab.id === "domains") {
+                    activeColor = "bg-dark text-light border border-dark shadow-[4px_4px_0_var(--color-dark)]";
                   } else if (tab.id === "danger") {
                     activeColor = "bg-danger text-light border border-dark shadow-[4px_4px_0_var(--color-dark)]";
                   }
@@ -636,6 +643,8 @@ export default function SettingsPage() {
                   </div>
                 </div>
               )}
+
+              {activeTab === "domains" && <CustomDomains />}
 
               {activeTab === "danger" && (
                 <div className="space-y-6">

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -622,7 +622,31 @@
     "toastLinksDeleteFailed": "Failed to delete links",
     "toastAccountDeleted": "Account deleted successfully",
     "toastAccountDeleteFailed": "Failed to delete account",
-    "toastError": "An error occurred"
+    "toastError": "An error occurred",
+    "tabDomains": "Domains"
+  },
+  "CustomDomains": {
+    "title": "Custom Domain",
+    "description": "Use a dedicated subdomain for your shortened links. Create a CNAME record pointing to {target} and then add it below.",
+    "subdomainNote": "Must be a subdomain — e.g. go.yourdomain.com. Root domains are not supported.",
+    "dnsType": "Type",
+    "dnsName": "Name",
+    "dnsValue": "Value",
+    "placeholder": "go.yourdomain.com",
+    "loading": "Loading domains…",
+    "empty": "No custom domains added yet.",
+    "statusPending": "Pending",
+    "statusVerifying": "Verifying…",
+    "statusActive": "Active",
+    "statusError": "Error",
+    "btnVerify": "Verify DNS",
+    "btnRemove": "Remove domain",
+    "toastVerifySuccess": "Domain verified successfully",
+    "toastVerifyFailed": "DNS verification failed. Check your CNAME record and try again.",
+    "toastAddFailed": "Failed to add domain",
+    "toastRemoveFailed": "Failed to remove domain",
+    "proOnly": "Custom domains are a PRO feature.",
+    "upgradePrompt": "Upgrade to PRO to use your own domain."
   },
   "NotFound": {
     "title": "Page Not Found",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -623,7 +623,31 @@
     "toastLinksDeleteFailed": "Error al eliminar los links",
     "toastAccountDeleted": "Cuenta eliminada exitosamente",
     "toastAccountDeleteFailed": "Error al eliminar la cuenta",
-    "toastError": "Ocurrió un error"
+    "toastError": "Ocurrió un error",
+    "tabDomains": "Dominios"
+  },
+  "CustomDomains": {
+    "title": "Dominio Personalizado",
+    "description": "Usa un subdominio dedicado para tus enlaces acortados. Crea un registro CNAME apuntando a {target} y añádelo abajo.",
+    "subdomainNote": "Debe ser un subdominio — por ejemplo go.tudominio.com. Los dominios raíz no están soportados.",
+    "dnsType": "Tipo",
+    "dnsName": "Nombre",
+    "dnsValue": "Valor",
+    "placeholder": "go.tudominio.com",
+    "loading": "Cargando dominios…",
+    "empty": "Todavía no hay dominios personalizados.",
+    "statusPending": "Pendiente",
+    "statusVerifying": "Verificando…",
+    "statusActive": "Activo",
+    "statusError": "Error",
+    "btnVerify": "Verificar DNS",
+    "btnRemove": "Eliminar dominio",
+    "toastVerifySuccess": "Dominio verificado correctamente",
+    "toastVerifyFailed": "La verificación DNS falló. Comprueba tu registro CNAME e inténtalo de nuevo.",
+    "toastAddFailed": "Error al añadir el dominio",
+    "toastRemoveFailed": "Error al eliminar el dominio",
+    "proOnly": "Los dominios personalizados son una función PRO.",
+    "upgradePrompt": "Actualiza a PRO para usar tu propio dominio."
   },
   "NotFound": {
     "title": "Página No Encontrada",


### PR DESCRIPTION
- Add CustomDomain model to Prisma schema with PENDING/VERIFYING/ACTIVE/ERROR statuses
- Add /domain routes (list, add, verify DNS, delete) restricted to PRO plan
- Add /internal/check-domain endpoint for Caddy on-demand TLS verification
- Modify redirectLink to resolve slugs scoped to custom domain owner via Host header
- Validate that custom domains are subdomains (e.g. go.domain.com), not root domains
- Add Caddyfile with on-demand TLS config for user custom domains
- Add CustomDomains component in Settings with PRO gate, DNS instructions, and status UI
- Add i18n translations (en/es) for all custom domain strings
- Add 15 tests covering all domain controller endpoints and edge cases