### PR TITLE
feat: link custom domain assignment for PRO users

### DIFF
--- a/backend/v2/controllers/link.js
+++ b/backend/v2/controllers/link.js
@@ -32,11 +32,27 @@ const createLink = async (req, res) => {
     return errorResponse(res, ERRORS.INVALID_DATA, issues);
   }
 
-  const { longUrl, status, customSuffix } = validate.data;
+  const { longUrl, status, customSuffix, customDomainId } = validate.data;
 
   // Custom suffix only allowed for authenticated users (not guests)
   if (customSuffix && isGuest) {
     return errorResponse(res, ERRORS.UNAUTHORIZED);
+  }
+
+  // Custom domain only allowed for authenticated users
+  if (customDomainId && isGuest) {
+    return errorResponse(res, ERRORS.UNAUTHORIZED);
+  }
+
+  // Validate that the custom domain belongs to this user and is ACTIVE
+  if (customDomainId && user) {
+    const domain = await prisma.customDomain.findUnique({ where: { id: customDomainId } });
+    if (!domain || domain.userId !== user.id) {
+      return errorResponse(res, ERRORS.DOMAIN_NOT_FOUND);
+    }
+    if (domain.status !== "ACTIVE") {
+      return errorResponse(res, ERRORS.INVALID_DATA, [{ field: "customDomainId", message: "Custom domain is not active" }]);
+    }
   }
 
   // Check link limit (skip if unlimited - null)
@@ -85,8 +101,9 @@ const createLink = async (req, res) => {
         status: status ?? true,
         shortUrl,
         groupId: groupId || null,
+        customDomainId: customDomainId || null,
       },
-      include: { tags: { include: { tag: true } } },
+      include: { tags: { include: { tag: true } }, customDomain: true },
     });
     return successResponse(res, link, 201);
   } catch (error) {
@@ -182,6 +199,7 @@ const getAllLinks = async (req, res) => {
       include: {
         tags: { include: { tag: true } },
         group: true,
+        customDomain: true,
       },
       orderBy: { createdAt: "desc" },
     });
@@ -207,6 +225,7 @@ const getAllLinks = async (req, res) => {
         scanCount: link.scanCount || 0,
         group: link.group,
         tags: link.tags.map((lt) => lt.tag),
+        customDomain: link.customDomain,
       };
     });
 
@@ -239,11 +258,22 @@ const updateLink = async (req, res) => {
     return errorResponse(res, ERRORS.INVALID_DATA, issues);
   }
 
-  const { longUrl, status, newShortUrl } = validatedData.data;
+  const { longUrl, status, newShortUrl, customDomainId } = validatedData.data;
 
   // Custom suffix change only allowed for authenticated users (not guests)
   if (newShortUrl !== undefined && guest) {
     return errorResponse(res, ERRORS.UNAUTHORIZED);
+  }
+
+  // Validate custom domain if provided
+  if (customDomainId && user) {
+    const domain = await prisma.customDomain.findUnique({ where: { id: customDomainId } });
+    if (!domain || domain.userId !== user.id) {
+      return errorResponse(res, ERRORS.DOMAIN_NOT_FOUND);
+    }
+    if (domain.status !== "ACTIVE") {
+      return errorResponse(res, ERRORS.INVALID_DATA, [{ field: "customDomainId", message: "Custom domain is not active" }]);
+    }
   }
 
   try {
@@ -281,6 +311,7 @@ const updateLink = async (req, res) => {
     if (longUrl !== undefined) updateData.longUrl = longUrl;
     if (status !== undefined) updateData.status = status;
     if (newShortUrl !== undefined) updateData.shortUrl = newShortUrl;
+    if (customDomainId !== undefined) updateData.customDomainId = customDomainId ?? null;
 
     // groupId: allow null to ungroup, or a valid group id (auth users only)
     if (req.body.groupId !== undefined && user) {
@@ -297,7 +328,7 @@ const updateLink = async (req, res) => {
     const updatedLink = await prisma.link.update({
       where: { shortUrl },
       data: updateData,
-      include: { tags: { include: { tag: true } }, group: true },
+      include: { tags: { include: { tag: true } }, group: true, customDomain: true },
     });
 
     return successResponse(res, {
@@ -307,6 +338,7 @@ const updateLink = async (req, res) => {
       createdAt: updatedLink.createdAt,
       group: updatedLink.group,
       tags: updatedLink.tags.map((lt) => lt.tag),
+      customDomain: updatedLink.customDomain,
     });
   } catch (error) {
     if (error.code === "P2002") {

--- a/backend/v2/prisma/schema.prisma
+++ b/backend/v2/prisma/schema.prisma
@@ -73,9 +73,12 @@ model Link {
   scanCount      Int          @default(0)
   createdAt      DateTime     @default(now())
 
-  user           User?        @relation(fields: [userId], references: [id])
+  customDomainId Int?
+
+  user           User?         @relation(fields: [userId], references: [id])
   guestSession   GuestSession? @relation(fields: [guestSessionId], references: [id])
-  group          Group?       @relation(fields: [groupId], references: [id], onDelete: SetNull)
+  group          Group?        @relation(fields: [groupId], references: [id], onDelete: SetNull)
+  customDomain   CustomDomain? @relation(fields: [customDomainId], references: [id], onDelete: SetNull)
   accesses       Access[]
   rules          LinkRule[]
   qrConfig       QRConfig?
@@ -83,6 +86,7 @@ model Link {
 
   @@index([shortUrl])
   @@index([userId, groupId])
+  @@index([customDomainId])
 }
 
 model Group {
@@ -324,6 +328,7 @@ model CustomDomain {
   verifiedAt DateTime?
   createdAt  DateTime           @default(now())
   updatedAt  DateTime           @updatedAt
+  links      Link[]
 
   @@index([userId])
   @@index([domain, status])

--- a/backend/v2/validators/link.js
+++ b/backend/v2/validators/link.js
@@ -36,12 +36,14 @@ const createLinkSchema = z.object({
   longUrl: longUrlSchema,
   status: z.boolean().default(true),
   customSuffix: customSuffixSchema.optional(),
+  customDomainId: z.number().int().positive().optional().nullable(),
 });
 
 const updateLinkSchema = z.object({
   longUrl: longUrlSchema.optional(),
   status: z.boolean().optional(),
   newShortUrl: customSuffixSchema.optional(),
+  customDomainId: z.number().int().positive().optional().nullable(),
 });
 
 module.exports = {

--- a/frontend/app/components/Drawer/CreateLinkDrawer.tsx
+++ b/frontend/app/components/Drawer/CreateLinkDrawer.tsx
@@ -14,6 +14,8 @@ import { useAuth } from '@/app/hooks';
 import { PLAN_LIMITS } from '@/app/constants/limits';
 import AnimatedText, { AnimatedTextRef } from '../ui/AnimatedText';
 import { useTranslations } from 'next-intl';
+import { domainService, CustomDomain } from '@/app/services/api/domainService';
+import SelectDropdown from '@/app/components/ui/Select/SelectDropdown';
 
 interface CreateLinkDrawerProps {
     open: boolean;
@@ -32,11 +34,13 @@ export default function CreateLinkDrawer({ open, onClose, onSuccess }: CreateLin
         longUrl: '',
         status: true,
         customSuffix: '',
+        customDomainId: null as number | null,
     });
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState('');
     const [suffixError, setSuffixError] = useState('');
     const [localRules, setLocalRules] = useState<LinkRuleType[]>([]);
+    const [activeDomains, setActiveDomains] = useState<CustomDomain[]>([]);
 
     // Ref for animated text
     const statusButtonTextRef = useRef<AnimatedTextRef>(null);
@@ -55,6 +59,14 @@ export default function CreateLinkDrawer({ open, onClose, onSuccess }: CreateLin
             setShowStatusBar("none");
         }
     }, [newLink]);
+
+    useEffect(() => {
+        if (open && !isGuest && user?.role === 'PRO') {
+            domainService.getAll().then(domains => {
+                setActiveDomains(domains.filter(d => d.status === 'ACTIVE'));
+            }).catch(() => {});
+        }
+    }, [open, isGuest, user?.role]);
 
     // Process conditions to convert country string to array and filter "always"
     const processConditions = (conditions: RuleCondition[]) => {
@@ -93,6 +105,7 @@ export default function CreateLinkDrawer({ open, onClose, onSuccess }: CreateLin
             longUrl: newLink.longUrl,
             status: newLink.status,
             ...(newLink.customSuffix && { customSuffix: newLink.customSuffix }),
+            ...(newLink.customDomainId && { customDomainId: newLink.customDomainId }),
         });
 
         if (response.success && response.data) {
@@ -134,6 +147,7 @@ export default function CreateLinkDrawer({ open, onClose, onSuccess }: CreateLin
                 longUrl: '',
                 status: true,
                 customSuffix: '',
+                customDomainId: null,
             });
             setLocalRules([]);
             onClose();
@@ -320,9 +334,34 @@ export default function CreateLinkDrawer({ open, onClose, onSuccess }: CreateLin
                             <p className='text-xs text-danger'>{suffixError}</p>
                         ) : (
                             <p className='text-xs text-dark/40 font-mono'>
-                                linkkk.dev/r/<span className='text-dark/70'>{newLink.customSuffix || t('customSuffixPlaceholder')}</span>
+                                {newLink.customDomainId
+                                    ? activeDomains.find(d => d.id === newLink.customDomainId)?.domain
+                                    : 'linkkk.dev'}/r/<span className='text-dark/70'>{newLink.customSuffix || t('customSuffixPlaceholder')}</span>
                             </p>
                         )}
+                    </motion.div>
+                )}
+
+                {/* Custom Domain (PRO users only) */}
+                {isAuthenticated && !isGuest && user?.role === 'PRO' && (
+                    <motion.div
+                        initial={{ opacity: 0, x: 20 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        transition={{ delay: 0.25, duration: 0.4, ease: "backInOut" }}
+                        className='w-full flex flex-col gap-1.5'
+                    >
+                        <p className='text-xs font-semibold text-dark/40 uppercase tracking-wide'>
+                            {t('customDomain')} <span className='normal-case font-normal'>({t('customDomainOptional')})</span>
+                        </p>
+                        <SelectDropdown
+                            mode="single"
+                            options={activeDomains.map(d => ({ label: d.domain, value: d.id }))}
+                            value={newLink.customDomainId}
+                            onChange={(val) => setNewLink({ ...newLink, customDomainId: val as number | null })}
+                            placeholder={t('customDomainNone')}
+                            showNoneOption
+                            noneLabel={t('customDomainNone')}
+                        />
                     </motion.div>
                 )}
 
@@ -439,6 +478,7 @@ export default function CreateLinkDrawer({ open, onClose, onSuccess }: CreateLin
                                                 longUrl: '',
                                                 status: true,
                                                 customSuffix: '',
+                                                customDomainId: null,
                                             });
                                             setLocalRules([]);
                                             setSuffixError('');

--- a/frontend/app/components/Drawer/EditiLinkDrawer.tsx
+++ b/frontend/app/components/Drawer/EditiLinkDrawer.tsx
@@ -4,6 +4,7 @@ import { FiCornerDownRight } from 'react-icons/fi';
 import { TbCircleDashed, TbCircleDashedCheck, TbCopy, TbList, TbPalette, TbCategory, TbPuzzle, TbQrcode, TbPencil, TbClick, TbWorld, TbShieldX, TbRobot, TbTag, TbFolder } from 'react-icons/tb';
 import Button from '../ui/Button/Button';
 import { useLinks, useAuth, useTags, useGroups } from '@/app/hooks';
+import { domainService, CustomDomain } from '@/app/services/api/domainService';
 import SelectDropdown from '@/app/components/ui/Select/SelectDropdown';
 import { PLAN_LIMITS } from '@/app/constants/limits';
 import type { Link } from '@/app/types';
@@ -87,6 +88,9 @@ export default function EditiLinkDrawer({ open, onClose, link }: EditiLinkDrawer
     const [selectedGroupId, setSelectedGroupId] = useState<number | null>(link.group?.id ?? null);
     const organizeLimit = user?.role === 'PRO' ? PLAN_LIMITS.pro : PLAN_LIMITS.user;
 
+    // Custom domain state
+    const [activeDomains, setActiveDomains] = useState<CustomDomain[]>([]);
+
     // QR state
     const [isDownloadingQR, setIsDownloadingQR] = useState(false);
     const [hasQRChanges, setHasQRChanges] = useState(false);
@@ -111,8 +115,13 @@ export default function EditiLinkDrawer({ open, onClose, link }: EditiLinkDrawer
             fetchQRConfig();
             fetchTags();
             fetchGroups();
+            if (user?.role === 'PRO') {
+                domainService.getAll().then(domains => {
+                    setActiveDomains(domains.filter(d => d.status === 'ACTIVE'));
+                }).catch(() => {});
+            }
         }
-    }, [open, isGuest, fetchQRConfig, fetchTags, fetchGroups]);
+    }, [open, isGuest, user?.role, fetchQRConfig, fetchTags, fetchGroups]);
 
 
 
@@ -181,6 +190,9 @@ export default function EditiLinkDrawer({ open, onClose, link }: EditiLinkDrawer
                 longUrl: newLink.longUrl,
                 status: newLink.status,
                 ...(newLink.shortUrl !== link.shortUrl && { newShortUrl: newLink.shortUrl }),
+                ...((newLink.customDomain?.id ?? null) !== (link.customDomain?.id ?? null) && {
+                    customDomainId: newLink.customDomain?.id ?? null,
+                }),
             });
 
             if (!response.success) {
@@ -225,7 +237,8 @@ export default function EditiLinkDrawer({ open, onClose, link }: EditiLinkDrawer
                 const hasChanges =
                     link.status !== newLink.status ||
                     link.longUrl !== newLink.longUrl ||
-                    link.shortUrl !== newLink.shortUrl;
+                    link.shortUrl !== newLink.shortUrl ||
+                    (link.customDomain?.id ?? null) !== (newLink.customDomain?.id ?? null);
                 if (hasChanges) {
                     e.preventDefault();
                     setShowStatusBar("loading");
@@ -249,7 +262,8 @@ export default function EditiLinkDrawer({ open, onClose, link }: EditiLinkDrawer
         const hasLinkChanges =
             link.status !== newLink.status ||
             link.longUrl !== newLink.longUrl ||
-            link.shortUrl !== newLink.shortUrl;
+            link.shortUrl !== newLink.shortUrl ||
+            (link.customDomain?.id ?? null) !== (newLink.customDomain?.id ?? null);
 
         const hasChanges = hasLinkChanges || hasRulesChanges || hasQRChanges;
 
@@ -319,7 +333,9 @@ export default function EditiLinkDrawer({ open, onClose, link }: EditiLinkDrawer
                                 {editingShortUrl ? (
                                     <div className='flex flex-col gap-1'>
                                         <div className='flex items-center gap-1'>
-                                            <span className='text-xl md:text-2xl italic font-black text-dark/40 whitespace-nowrap'>linkkk.dev/r/</span>
+                                            <span className='text-xl md:text-2xl italic font-black text-dark/40 whitespace-nowrap'>
+                                                {newLink.customDomain?.domain ?? 'linkkk.dev'}/r/
+                                            </span>
                                             <input
                                                 autoFocus
                                                 value={newLink.shortUrl}
@@ -352,7 +368,7 @@ export default function EditiLinkDrawer({ open, onClose, link }: EditiLinkDrawer
                                         >
                                             <AnimatedText
                                                 ref={shortUrlTextRef}
-                                                initialText={`linkkk.dev/r/${newLink.shortUrl}`}
+                                                initialText={`${newLink.customDomain?.domain ?? 'linkkk.dev'}/r/${newLink.shortUrl}`}
                                                 animationType="slide"
                                                 triggerMode="none"
                                             />
@@ -368,7 +384,8 @@ export default function EditiLinkDrawer({ open, onClose, link }: EditiLinkDrawer
                                                 className='text-dark/30 hover:text-dark/70'
                                                 onMouseDown={(e) => {
                                                     e.preventDefault();
-                                                    navigator.clipboard.writeText(`https://linkkk.dev/r/${newLink.shortUrl}`);
+                                                    const domain = newLink.customDomain?.domain ?? 'linkkk.dev';
+                                                    navigator.clipboard.writeText(`https://${domain}/r/${newLink.shortUrl}`);
                                                     shortUrlTextRef.current?.setText(t('copied'));
                                                     setTimeout(() => shortUrlTextRef.current?.reset(), 2000);
                                                 }}
@@ -541,6 +558,30 @@ export default function EditiLinkDrawer({ open, onClose, link }: EditiLinkDrawer
                                                     placeholder={t('organizeNoGroup')}
                                                     showNoneOption
                                                     noneLabel={t('organizeNoGroup')}
+                                                />
+                                            </motion.div>
+                                        )}
+
+                                        {/* Custom domain dropdown (PRO only) */}
+                                        {!isGuest && user?.role === 'PRO' && activeDomains.length > 0 && (
+                                            <motion.div
+                                                initial={{ opacity: 0, x: 20 }}
+                                                animate={{ opacity: 1, x: 0 }}
+                                                transition={{ delay: 0.25, duration: 0.4, ease: "backInOut" }}
+                                                className='flex flex-col gap-1'
+                                            >
+                                                <span className='text-xs font-semibold text-dark/40 flex items-center gap-1'><TbWorld size={12} /> {t('customDomain')}</span>
+                                                <SelectDropdown
+                                                    mode="single"
+                                                    options={activeDomains.map(d => ({ label: d.domain, value: d.id }))}
+                                                    value={newLink.customDomain?.id ?? null}
+                                                    onChange={(val) => {
+                                                        const domain = val ? activeDomains.find(d => d.id === val) ?? null : null;
+                                                        setNewLink(prev => ({ ...prev, customDomain: domain }));
+                                                    }}
+                                                    placeholder={t('customDomainNone')}
+                                                    showNoneOption
+                                                    noneLabel={t('customDomainNone')}
                                                 />
                                             </motion.div>
                                         )}

--- a/frontend/app/types/index.ts
+++ b/frontend/app/types/index.ts
@@ -46,6 +46,13 @@ export interface UpdateGroupDTO {
   order?: number;
 }
 
+// CustomDomain type (minimal, for link associations)
+export interface CustomDomain {
+  id: number;
+  domain: string;
+  status: "PENDING" | "VERIFYING" | "ACTIVE" | "ERROR";
+}
+
 // Link types
 export interface Link {
   id?: number;
@@ -57,6 +64,7 @@ export interface Link {
   scanCount?: number;
   group?: Group | null;
   tags?: Tag[];
+  customDomain?: CustomDomain | null;
 }
 
 export interface CreateLinkDTO {
@@ -64,6 +72,7 @@ export interface CreateLinkDTO {
   status?: boolean;
   customSuffix?: string;
   groupId?: number | null;
+  customDomainId?: number | null;
 }
 
 export interface UpdateLinkDTO {
@@ -71,6 +80,7 @@ export interface UpdateLinkDTO {
   status?: boolean;
   newShortUrl?: string;
   groupId?: number | null;
+  customDomainId?: number | null;
 }
 
 // Filter types

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -306,7 +306,11 @@
     "customSuffixHint": "Letters, numbers, - and _ only. Min 3 characters.",
     "customSuffixInvalid": "Letters, numbers, hyphens and underscores only. Min 3.",
     "toastSuffixTaken": "Error creating link",
-    "toastSuffixTakenDesc": "That suffix is already taken. Try a different one."
+    "toastSuffixTakenDesc": "That suffix is already taken. Try a different one.",
+    "customDomain": "Custom domain",
+    "customDomainOptional": "optional",
+    "customDomainNone": "linkkk.dev (default)",
+    "customDomainProOnly": "Custom domains are a PRO feature"
   },
   "StatsDrawer": {
     "retentionTitle": "30-day history:",
@@ -376,6 +380,9 @@
     "customSuffixInvalid": "Letters, numbers, hyphens and underscores only. Min 3.",
     "toastSuffixTaken": "Error updating link",
     "toastSuffixTakenDesc": "That suffix is already taken. Try a different one.",
+    "customDomain": "Custom domain",
+    "customDomainOptional": "optional",
+    "customDomainNone": "linkkk.dev (default)",
     "clickToEdit": "Click to edit",
     "closeConfirmMessage": "You have unsaved changes. Close anyway?",
     "keepEditing": "Keep editing",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -306,7 +306,11 @@
     "customSuffixHint": "Solo letras, números, - y _. Mínimo 3 caracteres.",
     "customSuffixInvalid": "Solo letras, números, guiones y guiones bajos. Mínimo 3.",
     "toastSuffixTaken": "Error al crear el link",
-    "toastSuffixTakenDesc": "Ese sufijo ya está en uso. Prueba con otro."
+    "toastSuffixTakenDesc": "Ese sufijo ya está en uso. Prueba con otro.",
+    "customDomain": "Dominio personalizado",
+    "customDomainOptional": "opcional",
+    "customDomainNone": "linkkk.dev (por defecto)",
+    "customDomainProOnly": "Los dominios personalizados son una función PRO"
   },
   "StatsDrawer": {
     "retentionTitle": "Historial de 30 días:",
@@ -377,6 +381,9 @@
     "customSuffixInvalid": "Solo letras, números, guiones y guiones bajos. Mínimo 3.",
     "toastSuffixTaken": "Error al actualizar el link",
     "toastSuffixTakenDesc": "Ese sufijo ya está en uso. Prueba con otro.",
+    "customDomain": "Dominio personalizado",
+    "customDomainOptional": "opcional",
+    "customDomainNone": "linkkk.dev (por defecto)",
     "clickToEdit": "Haz clic para editar",
     "closeConfirmMessage": "Tienes cambios sin guardar. ¿Cerrar igualmente?",
     "keepEditing": "Seguir editando",

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -21,14 +21,18 @@ const nextConfig: NextConfig = {
       },
     ],
   },
-  webpack: (config) => {
+  webpack: (config, { isServer }) => {
     // Force a single React instance to prevent duplicate module errors
     // caused by pnpm resolving paths with different casing on Windows.
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      react: path.resolve('./node_modules/react'),
-      'react-dom': path.resolve('./node_modules/react-dom'),
-    };
+    // Only applied on the client bundle — next-devtools (server/edge) manages
+    // its own React context and breaks if we override its resolution.
+    if (!isServer) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        react: path.resolve('./node_modules/react'),
+        'react-dom': path.resolve('./node_modules/react-dom'),
+      };
+    }
     return config;
   },
 };


### PR DESCRIPTION
- Add customDomainId to Link model with FK to CustomDomain (onDelete: SetNull)
- Validate domain ownership and ACTIVE status on create/update
- Return customDomain object in getAllLinks and updateLink responses
- Add domain selector in CreateLinkDrawer and EditLinkDrawer (PRO only)
- URL preview and copy button use the assigned custom domain
- Fix webpack React alias to client bundle only, preventing next-devtools conflict