### PR TITLE
fix: custom domain redirect and dashboard display

### DIFF
--- a/backend/v2.js
+++ b/backend/v2.js
@@ -235,8 +235,16 @@ app.get("/internal/check-domain", (req, res, next) => {
   return next();
 }, checkDomainForCaddy);
 
-// Public redirect endpoint (LAST - catches everything else)
+// Public redirect endpoint via linkkk.dev/r/:shortUrl
 app.get("/r/:shortUrl", redirectLink);
+
+// Custom domain redirect — catches /:shortUrl when the request comes from a
+// non-linkkk.dev host. Registered after /r/ so it never conflicts.
+app.get("/:shortUrl", (req, res, next) => {
+  const host = (req.headers["host"] || "").split(":")[0].toLowerCase();
+  if (host === "linkkk.dev" || host.endsWith(".linkkk.dev")) return next();
+  return redirectLink(req, res, next);
+});
 
 // ============================================================================
 // ERROR HANDLING MIDDLEWARE

--- a/backend/v2/controllers/link.js
+++ b/backend/v2/controllers/link.js
@@ -463,11 +463,18 @@ const redirectLink = async (req, res) => {
           },
           orderBy: { priority: "asc" },
         },
+        customDomain: true,
       },
     });
 
     if (!link) {
       return res.redirect(`${config.frontend.url}/404?url=${shortUrl}`);
+    }
+
+    // If the link has a custom domain assigned but the request came through
+    // linkkk.dev/r/, redirect to the canonical custom domain URL instead.
+    if (link.customDomain && customDomainUserId === null) {
+      return res.redirect(301, `https://${link.customDomain.domain}/${shortUrl}`);
     }
 
     // Check status

--- a/frontend/app/components/LinkList/LinkItem.tsx
+++ b/frontend/app/components/LinkList/LinkItem.tsx
@@ -40,7 +40,8 @@ export default function LinkItem({ view, data }: LinkItemProps) {
                             className='text-dark/40 hover:text-info hover:bg-info/10'
                             onClick={(e) => {
                                 e.stopPropagation();
-                                navigator.clipboard.writeText(`https://linkkk.dev/r/${data.shortUrl}`);
+                                const domain = data.customDomain ? data.customDomain.domain : 'linkkk.dev/r';
+                                navigator.clipboard.writeText(`https://${domain}/${data.shortUrl}`);
                             }}
                         />
                         <Button
@@ -80,7 +81,9 @@ export default function LinkItem({ view, data }: LinkItemProps) {
                             {/* URLs */}
                             <div className='flex flex-col w-full sm:max-w-1/2 gap-1'>
                                 <div className='flex items-center gap-2'>
-                                    <p className='text-lg italic'>linkkk.dev/r/<span className='font-bold'>{data.shortUrl}</span></p>
+                                    <p className='text-lg italic'>
+                                        {data.customDomain ? data.customDomain.domain : 'linkkk.dev/r'}/<span className='font-bold'>{data.shortUrl}</span>
+                                    </p>
                                     {/* Group badge */}
                                     {data.group && (
                                         <div className='flex items-center gap-1 text-sm px-2 py-1 rounded-full border' style={{ color: data.group.color ?? '#6b7280', backgroundColor: (data.group.color ?? '#6b7280') + '22' }}>


### PR DESCRIPTION
- Add /:shortUrl route for custom domain hosts (no /r/ prefix needed)
- Redirect linkkk.dev/r/slug to canonical custom domain URL (301) when the link has a customDomain assigned, instead of serving it directly
- LinkItem now shows the correct domain (custom or linkkk.dev/r) in the dashboard and uses it when copying the link URL